### PR TITLE
docs: correct capitalization of merge commands

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
         </tr>
         <tr>
             <td>gmom</td>
-            <td>Git merge origin/master</td>
+            <td>git merge origin/master</td>
         </tr>
         <tr>
             <td>gmt</td>
@@ -220,15 +220,15 @@
         </tr>
         <tr>
             <td>gmtvim</td>
-            <td>Git mergetool --no-prompt --tool=vimdiff</td>
+            <td>git mergetool --no-prompt --tool=vimdiff</td>
         </tr>
         <tr>
             <td>gmum</td>
-            <td>Git merge upstream/master</td>
+            <td>git merge upstream/master</td>
         </tr>
         <tr>
             <td>gma</td>
-            <td>Git merge --abort</td>
+            <td>git merge --abort</td>
         </tr>
     </table>
     <table id="remotes">


### PR DESCRIPTION
Several commands used `Git` vs. `git`. Update commands, i.e., `s/Git/git/g`